### PR TITLE
35 revisit dockerfile routine

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,13 @@ nd_docker_compose_remove_project: true
 #
 # Role configuration options.
 #
+# Set `no_log` property on tasks that may expose sensitive variables. Should
+# always be true, but may be useful for debugging.
 nd_secure_no_log: true
+# Permit default passwords. Should always be false, but can be disabled for
+# testing.
 nd_allow_insecure_defaults: false
-nd_use_letsencrypt: true
-# nd_use_redis: true
-# nd_use_cron: true
+
 nd_domain_name: "example.local"
 nd_nextcloud_install_tasks_file: "nd-nextcloud-install.yml"
 nd_nextcloud_post_install_tasks_file: "nd-nextcloud-post-install.yml"
@@ -27,12 +29,6 @@ nd_nextcloud_post_install_tasks_file: "nd-nextcloud-post-install.yml"
 nd_postgres_password: "insecure"
 nd_redis_host_password: "insecure"
 nd_nextcloud_admin_password: "insecure"
-
-#
-# Service environment vars and volumes.
-#
-
-nd_nextcloud_required_apps: []
 
 #
 # PostgreSQL
@@ -73,8 +69,10 @@ nd_nextcloud_occ_commands:
   - command: "encryption:enable"
   - command: "app:enable {{ nd_nextcloud_encryption_module }}"
 
+
 nd_docker_network: "proxy-tier"
 
+# These are all the volumes used in the `volumes` section of docker-compose.yml.
 nd_docker_volumes:
   db: "db"
   app: "nextcloud"
@@ -83,6 +81,21 @@ nd_docker_volumes:
     conf: "vhost.d"
     docroot: "html"
 
+# These variables used to populate values in docker-compose.yml. To keep things
+# simple and flexible, we're only populating environment variables, networks,
+# and volumes.
+#
+# When deploying a different set of containers, modify the docker-compose.yml.j2
+# to include only the required containers, and update this set of variables.
+#
+# Since this is a dict, you can add your own keys. So if, for example, you
+# prefer to provide your own SSL certs instead of using Letsencrypt, it's
+# possible to add a key like `omgwtfssl` (using the  paulczar/omgwtfssl
+# container), and add volumes and environment variabless here.
+#
+# Then, modify the docker-compose.yml.j2 template to include the omgwtfssl
+# container, using the existing containers as models for how to correctly
+# output the variables as correct yaml.
 nd_docker_compose:
   app:
     environment:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,8 +14,8 @@ nd_docker_compose_remove_project: true
 #
 nd_allow_insecure_defaults: false
 nd_use_letsencrypt: true
-nd_use_redis: true
-nd_use_cron: true
+# nd_use_redis: true
+# nd_use_cron: true
 nd_domain_name: "example.local"
 nd_nextcloud_install_tasks_file: "nd-nextcloud-install.yml"
 nd_nextcloud_post_install_tasks_file: "nd-nextcloud-post-install.yml"
@@ -31,21 +31,7 @@ nd_nextcloud_admin_password: "insecure"
 # Service environment vars and volumes.
 #
 
-#
-# Letsencrypt
-#
-# Env vars.
-nd_letsencrypt_env_vars:
-  - name: "LETSENCRYPT_HOST"
-    value: "{{ nd_domain_name }}"
-  - name: "LETSENCRYPT_EMAIL"
-    value: "admin@example.local"
 nd_nextcloud_required_apps: []
-
-# Volumes.
-nd_letsencrypt_required_volumes:
-  - "certs:/etc/nginx/certs"
-  - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
 #
 # PostgreSQL
@@ -53,49 +39,6 @@ nd_letsencrypt_required_volumes:
 nd_postgres_database: "nextcloud"
 nd_postgres_host: "db"
 nd_postgres_user: "nextcloud"
-
-# Env vars.
-nd_postgres_env_vars:
-  - name: "POSTGRES_DB"
-    value: "{{ nd_postgres_database }}"
-  - name: "POSTGRES_HOST"
-    value: "{{ nd_postgres_host }}"
-  - name: "POSTGRES_PASSWORD"
-    value: "{{ nd_postgres_password }}"
-  - name: "POSTGRES_USER"
-    value: "{{ nd_postgres_user }}"
-
-# Volumes.
-nd_postgres_required_volumes:
-  - "db:/var/lib/postgresql/data"
-
-#
-# Nextcloud
-#
-# Env vars.
-nd_nextcloud_env_vars:
-  - name: "VIRTUAL_HOST"
-    value: "{{ nd_domain_name }}"
-  - name: "POSTGRES_HOST"
-    value: "db"
-
-# Volumes.
-nd_nextcloud_required_volumes:
-  - "nextcloud:/var/www/html"
-  # - "/var/nextcloud/config:/var/www/html/config"
-  # - "/var/nextcloud/custom_apps:/var/www/html/custom_apps"
-  # - "/var/nextcloud/data:/var/www/html/data"
-  # - "/var/nextcloud/themes:/var/www/html/themes"
-
-#
-# Nginx Proxy
-#
-# Volumes.
-nd_nginx_proxy_required_volumes:
-  - "vhost.d:/etc/nginx/vhost.d"
-  - "html:/usr/share/nginx/html"
-  - "/var/run/docker.sock:/tmp/docker.sock:ro"
-  # - "/var/nextcloud/proxy/conf.d:/etc/nginx/conf.d"
 
 #
 # Redis
@@ -108,6 +51,8 @@ nd_redis_env_vars:
     value: "6379"
   - name: "REDIS_HOST_PASSWORD"
     value: "{{ nd_redis_host_password }}"
+
+#
 
 #
 # Nextcloud install, setup related vars.
@@ -134,3 +79,45 @@ nd_nextcloud_occ_commands:
   - command: "config:system:set trusted_domains 1 --value={{ nd_domain_name }}"
   - command: "encryption:enable"
   - command: "app:enable {{ nd_nextcloud_encryption_module }}"
+
+nd_docker_network: "proxy-tier"
+
+nd_docker_volumes:
+  db: "db"
+  app: "nextcloud"
+  letsencrypt-companion: "certs"
+  proxy:
+    conf: "vhost.d"
+    docroot: "html"
+
+nd_docker_compose:
+  app:
+    environment:
+      - "VIRTUAL_HOST={{ nd_domain_name }}"
+      - "LETSENCRYPT_HOST={{ nd_domain_name }}"
+      - "LETSENCRYPT_EMAIL=admin@example.local"
+      - "POSTGRES_HOST={{ nd_postgres_host }}"
+    networks:
+      - "default"
+      - "{{ nd_docker_network }}"
+    volumes:
+      - "{{ nd_docker_volumes.app }}:/var/www/html"
+  db:
+    volumes:
+      - "{{ nd_docker_volumes.db }}:/var/lib/postgresql/data"
+  proxy:
+    networks:
+      - "{{ nd_docker_network }}"
+    volumes:
+      - "{{ nd_docker_volumes['letsencrypt-companion'] }}:/etc/nginx/certs:ro"
+      - "{{ nd_docker_volumes.proxy.conf }}:/etc/nginx/vhost.d"
+      - "{{ nd_docker_volumes.proxy.docroot }}:/usr/share/nginx/html"
+      - "/var/run/docker.sock:/tmp/docker.sock:ro"
+  letsencrypt-companion:
+    networks:
+      - "{{ nd_docker_network }}"
+    volumes:
+      - "{{ nd_docker_volumes['letsencrypt-companion'] }}:/etc/nginx/certs"
+      - "{{ nd_docker_volumes.proxy.conf }}:/etc/nginx/vhost.d"
+      - "{{ nd_docker_volumes.proxy.docroot }}:/usr/share/nginx/html"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ nd_docker_compose_remove_project: true
 #
 # Role configuration options.
 #
+nd_secure_no_log: true
 nd_allow_insecure_defaults: false
 nd_use_letsencrypt: true
 # nd_use_redis: true
@@ -43,16 +44,8 @@ nd_postgres_user: "nextcloud"
 #
 # Redis
 #
-# Env vars.
-nd_redis_env_vars:
-  - name: "REDIS_HOST"
-    value: "redis"
-  - name: "REDIS_HOST_PORT"
-    value: "6379"
-  - name: "REDIS_HOST_PASSWORD"
-    value: "{{ nd_redis_host_password }}"
-
-#
+nd_redis_host: "redis"
+nd_redis_port: "6379"
 
 #
 # Nextcloud install, setup related vars.
@@ -97,6 +90,7 @@ nd_docker_compose:
       - "LETSENCRYPT_HOST={{ nd_domain_name }}"
       - "LETSENCRYPT_EMAIL=admin@example.local"
       - "POSTGRES_HOST={{ nd_postgres_host }}"
+      - "REDIS_HOST={{ nd_redis_host }}"
     networks:
       - "default"
       - "{{ nd_docker_network }}"
@@ -126,3 +120,8 @@ nd_docker_compose:
       - "{{ nd_docker_volumes.proxy.conf }}:/etc/nginx/vhost.d"
       - "{{ nd_docker_volumes.proxy.docroot }}:/usr/share/nginx/html"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
+  redis:
+    environment:
+      - "REDIS_HOST={{ nd_redis_host }}"
+      - "REDIS_HOST_PORT={{ nd_redis_port }}"
+      - "REDIS_HOST_PASSWORD={{ nd_redis_host_password }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,11 @@ nd_docker_compose:
     volumes:
       - "{{ nd_docker_volumes.app }}:/var/www/html"
   db:
+    environment:
+      - "POSTGRES_DB={{ nd_postgres_database }}"
+      - "POSTGRES_HOST={{ nd_postgres_host }}"
+      - "POSTGRES_PASSWORD={{ nd_postgres_password }}"
+      - "POSTGRES_USER={{ nd_postgres_user }}"
     volumes:
       - "{{ nd_docker_volumes.db }}:/var/lib/postgresql/data"
   proxy:

--- a/files/docker-compose/db.env.j2
+++ b/files/docker-compose/db.env.j2
@@ -1,3 +1,3 @@
-{% for variable in nd_postgres_env_vars %}
-{{ variable.name }}={{ variable.value }}
+{% for variable in nd_docker_compose.db.environment %}
+{{ variable }}
 {% endfor %}

--- a/files/docker-compose/docker-compose.yml.j2
+++ b/files/docker-compose/docker-compose.yml.j2
@@ -8,7 +8,13 @@ services:
     volumes:
       {{ nd_docker_compose.db.volumes | to_nice_yaml | indent(width=6) }}
     env_file:
-      - db.env
+      - db.en
+
+  redis:
+    image: redis:alpine
+    restart: always
+    environment:
+      {{ nd_docker_compose.redis.environment | to_nice_yaml | indent(width=6) }}
 
   app:
     image: nextcloud:apache
@@ -21,8 +27,19 @@ services:
       - db.env
     depends_on:
       - db
+      - redis
     networks:
       {{ nd_docker_compose.app.networks | to_nice_yaml | indent(width=6) }}
+
+  cron:
+    image: nextcloud:apache
+    restart: always
+    volumes:
+      {{ nd_docker_compose.app.volumes | to_nice_yaml | indent(width=6) }}
+    entrypoint: /cron.sh
+    depends_on:
+      - db
+      - redis
 
   proxy:
     build: ./proxy

--- a/files/docker-compose/docker-compose.yml.j2
+++ b/files/docker-compose/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+---
 version: '3'
 
 services:
@@ -5,99 +6,53 @@ services:
     image: postgres:alpine
     restart: always
     volumes:
-{% for postgres_volume in nd_postgres_volumes %}
-      - {{ postgres_volume }}
-{% endfor %}
+      {{ nd_docker_compose.db.volumes | to_nice_yaml | indent(width=6) }}
     env_file:
       - db.env
 
-{% if nd_use_redis %}
-  redis:
-    image: redis:alpine
-    restart: always
-
-{% endif %}
   app:
     image: nextcloud:apache
     restart: always
     volumes:
-{% for nextcloud_volume in nd_nextcloud_volumes %}
-      - {{ nextcloud_volume }}
-{% endfor %}
+      {{ nd_docker_compose.app.volumes | to_nice_yaml | indent(width=6) }}
     environment:
-{% for variable in nd_nextcloud_env_vars %}
-      - {{ variable.name }}={{ variable.value }}
-{% endfor %}
+      {{ nd_docker_compose.app.environment | to_nice_yaml | indent(width=6) }}
     env_file:
       - db.env
     depends_on:
       - db
-{% if nd_use_redis %}
-      - redis
-{% endif %}
     networks:
-      - proxy-tier
-      - default
-
-{% if nd_use_cron %}
-  cron:
-    image: nextcloud:apache
-    restart: always
-    volumes:
-{% for cron_volume in nd_nextcloud_required_volumes %}
-      - {{ cron_volume }}
-{% endfor %}
-    entrypoint: /cron.sh
-    depends_on:
-      - db
-{% if nd_use_redis %}
-      - redis
-{% endif %}
-{% endif %}
+      {{ nd_docker_compose.app.networks | to_nice_yaml | indent(width=6) }}
 
   proxy:
     build: ./proxy
     restart: always
     ports:
       - 80:80
-{% if nd_use_letsencrypt %}
       - 443:443
-{% endif %}
-{% if nd_use_letsencrypt %}
     labels:
       com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
-{% endif %}
     volumes:
-{% for nginx_proxy_volume in nd_nginx_proxy_volumes %}
-{% if nginx_proxy_volume|regex_search('certs$') %}
-      - {{ nginx_proxy_volume }}:ro
-{% else %}
-      - {{ nginx_proxy_volume }}
-{% endif %}
-{% endfor %}
+      {{ nd_docker_compose.proxy.volumes | to_nice_yaml | indent(width=6) }}
     networks:
-      - proxy-tier
+      {{ nd_docker_compose.proxy.networks | to_nice_yaml | indent(width=6) }}
 
-{% if nd_use_letsencrypt %}
-  letsencrypt:
+  letsencrypt-companion:
     image: jrcs/letsencrypt-nginx-proxy-companion
     restart: always
     volumes:
-{% for letsencrypt_volume in nd_letsencrypt_volumes %}
-      - {{ letsencrypt_volume }}
-{% endfor %}
+      {{ nd_docker_compose['letsencrypt-companion'].volumes | to_nice_yaml | indent(width=6) }}
     networks:
-      - proxy-tier
+      {{ nd_docker_compose['letsencrypt-companion'].networks | to_nice_yaml | indent(width=6) }}
     depends_on:
       - proxy
 
-{% endif %}
 volumes:
-{% for volume in (nd_nextcloud_volumes + nd_nginx_proxy_volumes + nd_postgres_volumes)|unique %}
-{% if volume|regex_search('^[a-z.]+:') %}
-  {{ volume|regex_replace('^([a-z.]+:).*$', '\\1') }}
-{% endif %}
-{% endfor %}
+  {{ nd_docker_volumes.db }}:
+  {{ nd_docker_volumes.app}}:
+  {{ nd_docker_volumes['letsencrypt-companion']}}:
+  {{ nd_docker_volumes.proxy.conf }}:
+  {{ nd_docker_volumes.proxy.docroot }}:
 
 networks:
-  proxy-tier:
+  {{ nd_docker_network }}:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,13 +4,12 @@
   become: true
   become_user: root
   vars:
+    nd_docker_compose_project_src: "{{ playbook_dir }}/../files/docker-compose"
     nd_docker_compose_remove_project: false
     nd_domain_name: "instance"
     nd_postgres_password: "postgres-password"
     nd_redis_host_password: "redis-host-password"
     nd_nextcloud_admin_password: "nextcloud-admin-password"
-    nd_nextcloud_required_volumes:
-      - "nextcloud:/var/www/html"
     nd_docker_compose:
       app:
         environment:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,6 @@
   become: true
   become_user: root
   vars:
-    nd_use_letsencrypt: false
     nd_docker_compose_remove_project: false
     nd_domain_name: "instance"
     nd_postgres_password: "postgres-password"
@@ -12,9 +11,32 @@
     nd_nextcloud_admin_password: "nextcloud-admin-password"
     nd_nextcloud_required_volumes:
       - "nextcloud:/var/www/html"
-      - "/var/nextcloud/config:/var/www/html/config"
-      - "/var/nextcloud/custom_apps:/var/www/html/custom_apps"
-      - "/var/nextcloud/data:/var/www/html/data"
-      - "/var/nextcloud/themes:/var/www/html/themes"
+    nd_docker_compose:
+      app:
+        environment:
+          - "VIRTUAL_HOST={{ nd_domain_name }}"
+          - "LETSENCRYPT_HOST={{ nd_domain_name }}"
+          - "LETSENCRYPT_EMAIL=admin@example.local"
+          - "POSTGRES_HOST={{ nd_postgres_host }}"
+        networks:
+          - "default"
+          - "{{ nd_docker_network }}"
+        volumes:
+          - "{{ nd_docker_volumes.app }}:/var/www/html"
+      db:
+        environment:
+          - "POSTGRES_DB={{ nd_postgres_database }}"
+          - "POSTGRES_HOST={{ nd_postgres_host }}"
+          - "POSTGRES_PASSWORD={{ nd_postgres_password }}"
+          - "POSTGRES_USER={{ nd_postgres_user }}"
+        volumes:
+          - "{{ nd_docker_volumes.db }}:/var/lib/postgresql/data"
+      proxy:
+        networks:
+          - "{{ nd_docker_network }}"
+        volumes:
+          - "{{ nd_docker_volumes.proxy.conf }}:/etc/nginx/vhost.d"
+          - "{{ nd_docker_volumes.proxy.docroot }}:/usr/share/nginx/html"
+          - "/var/run/docker.sock:/tmp/docker.sock:ro"
   roles:
     - role: ansible-role-nextcloud-docker

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,6 +4,7 @@
   become: true
   become_user: root
   vars:
+    nd_secure_no_log: false
     nd_docker_compose_project_src: "{{ playbook_dir }}/../files/docker-compose"
     nd_docker_compose_remove_project: false
     nd_domain_name: "instance"
@@ -17,6 +18,7 @@
           - "LETSENCRYPT_HOST={{ nd_domain_name }}"
           - "LETSENCRYPT_EMAIL=admin@example.local"
           - "POSTGRES_HOST={{ nd_postgres_host }}"
+          - "REDIS_HOST={{ nd_redis_host }}"
         networks:
           - "default"
           - "{{ nd_docker_network }}"
@@ -37,5 +39,10 @@
           - "{{ nd_docker_volumes.proxy.conf }}:/etc/nginx/vhost.d"
           - "{{ nd_docker_volumes.proxy.docroot }}:/usr/share/nginx/html"
           - "/var/run/docker.sock:/tmp/docker.sock:ro"
+      redis:
+        environment:
+          - "REDIS_HOST={{ nd_redis_host }}"
+          - "REDIS_HOST_PORT={{ nd_redis_port }}"
+          - "REDIS_HOST_PASSWORD={{ nd_redis_host_password }}"
   roles:
     - role: ansible-role-nextcloud-docker

--- a/molecule/default/tests/test_nextcloud.py
+++ b/molecule/default/tests/test_nextcloud.py
@@ -28,7 +28,8 @@ def test_nextcloud_trusted_domains(host, trusted_domain):
   '\'dbtype\' => \'pgsql\','
 ])
 def test_nextcloud_configuration(host, config_line):
-    c = 'cat /var/nextcloud/config/config.php'
+    c = ('cat '
+         '/var/lib/docker/volumes/nextcloud_nextcloud/_data/config/config.php')
     r = host.run(c)
 
     assert config_line in r.stdout

--- a/molecule/files/docker-compose/db.env.j2
+++ b/molecule/files/docker-compose/db.env.j2
@@ -1,0 +1,3 @@
+{% for variable in nd_docker_compose.db.environment %}
+{{ variable }}
+{% endfor %}

--- a/molecule/files/docker-compose/docker-compose.yml.j2
+++ b/molecule/files/docker-compose/docker-compose.yml.j2
@@ -1,6 +1,6 @@
 ---
-# Used in molecule testing, so does not include any letsencrypt-companion
-# container vars or settings.
+# Used in molecule testing, so does not include any lets encrypt container
+# vars or settings.
 
 version: '3'
 
@@ -13,6 +13,12 @@ services:
     env_file:
       - db.env
 
+  redis:
+    image: redis:alpine
+    restart: always
+    environment:
+      {{ nd_docker_compose.redis.environment | to_nice_yaml | indent(width=6) }}
+
   app:
     image: nextcloud:apache
     restart: always
@@ -24,17 +30,25 @@ services:
       - db.env
     depends_on:
       - db
+      - redis
     networks:
       {{ nd_docker_compose.app.networks | to_nice_yaml | indent(width=6) }}
+
+  cron:
+    image: nextcloud:apache
+    restart: always
+    volumes:
+      {{ nd_docker_compose.app.volumes | to_nice_yaml | indent(width=6) }}
+    entrypoint: /cron.sh
+    depends_on:
+      - db
+      - redis
 
   proxy:
     build: ./proxy
     restart: always
     ports:
       - 80:80
-      - 443:443
-    labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
     volumes:
       {{ nd_docker_compose.proxy.volumes | to_nice_yaml | indent(width=6) }}
     networks:

--- a/molecule/files/docker-compose/docker-compose.yml.j2
+++ b/molecule/files/docker-compose/docker-compose.yml.j2
@@ -1,0 +1,50 @@
+---
+# Used in molecule testing, so does not include any letsencrypt-companion
+# container vars or settings.
+
+version: '3'
+
+services:
+  db:
+    image: postgres:alpine
+    restart: always
+    volumes:
+      {{ nd_docker_compose.db.volumes | to_nice_yaml | indent(width=6) }}
+    env_file:
+      - db.env
+
+  app:
+    image: nextcloud:apache
+    restart: always
+    volumes:
+      {{ nd_docker_compose.app.volumes | to_nice_yaml | indent(width=6) }}
+    environment:
+      {{ nd_docker_compose.app.environment | to_nice_yaml | indent(width=6) }}
+    env_file:
+      - db.env
+    depends_on:
+      - db
+    networks:
+      {{ nd_docker_compose.app.networks | to_nice_yaml | indent(width=6) }}
+
+  proxy:
+    build: ./proxy
+    restart: always
+    ports:
+      - 80:80
+      - 443:443
+    labels:
+      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
+    volumes:
+      {{ nd_docker_compose.proxy.volumes | to_nice_yaml | indent(width=6) }}
+    networks:
+      {{ nd_docker_compose.proxy.networks | to_nice_yaml | indent(width=6) }}
+
+volumes:
+  {{ nd_docker_volumes.db }}:
+  {{ nd_docker_volumes.app}}:
+  {{ nd_docker_volumes.proxy.conf }}:
+  {{ nd_docker_volumes.proxy.docroot }}:
+
+networks:
+  {{ nd_docker_network }}:

--- a/molecule/files/docker-compose/proxy/Dockerfile
+++ b/molecule/files/docker-compose/proxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM jwilder/nginx-proxy:alpine
+
+COPY uploadsize.conf /etc/nginx/conf.d/uploadsize.conf

--- a/molecule/files/docker-compose/proxy/uploadsize.conf
+++ b/molecule/files/docker-compose/proxy/uploadsize.conf
@@ -1,0 +1,2 @@
+client_max_body_size 10G;
+proxy_request_buffering off;

--- a/tasks/nd-docker-compose.yml
+++ b/tasks/nd-docker-compose.yml
@@ -13,7 +13,7 @@
     dest: "{{ nd_docker_compose_project_dir }}/db.env"
   changed_when: false
   # The env file may contain one or more passwords.
-  no_log: true
+  no_log: "{{ nd_secure_no_log }}"
 
 - name: Transfer dockerfile to remote.
   template:
@@ -21,7 +21,7 @@
     dest: "{{ nd_docker_compose_project_dir }}/docker-compose.yml"
   changed_when: false
   # The dockerfile may contain one or more passwords.
-  no_log: true
+  no_log: "{{ nd_secure_no_log }}"
 
 - name: Copy Nextcloud dockerfile dependencies to remote.
   copy:

--- a/tasks/nd-docker-compose.yml
+++ b/tasks/nd-docker-compose.yml
@@ -1,34 +1,6 @@
 ---
 # tasks related to docker-compose for ansible-role-nextcloud-docker.
 
-- name: Work out lists of volumes for various containers.
-  block:
-    - name: Set Nextcloud volumes.
-      set_fact:
-        nd_nextcloud_volumes: "{{ nd_nextcloud_required_volumes }}"
-
-    - name: Set PostgreSQL volumes.
-      set_fact:
-        nd_postgres_volumes: "{{ nd_postgres_required_volumes }}"
-
-    - name: Set Nginx Proxy volumes.
-      set_fact:
-        nd_nginx_proxy_volumes: "{{ (nd_nginx_proxy_required_volumes + nd_use_letsencrypt|ternary(nd_letsencrypt_required_volumes, []))|unique }}"
-
-    - name: Set Letsencrypt helper volumes.
-      set_fact:
-        nd_letsencrypt_volumes: "{{ (nd_letsencrypt_required_volumes + nd_nginx_proxy_required_volumes)|unique }}"
-
-- name: Create a list of env variables for Nextcloud.
-  set_fact:
-    nd_nextcloud_env_vars: >
-      {{ nd_nextcloud_env_vars
-      + (nd_use_redis is sameas true)|ternary(nd_redis_env_vars, [])
-      + (nd_use_letsencrypt is sameas true)|ternary(nd_letsencrypt_env_vars, []) }}
-  changed_when: false
-  # The list contains the redis password.
-  no_log: true
-
 - name: Create directory for docker-compose files on remote.
   file:
     path: "{{ nd_docker_compose_project_dir }}"
@@ -40,7 +12,7 @@
     src: "{{ nd_docker_compose_project_src }}/db.env.j2"
     dest: "{{ nd_docker_compose_project_dir }}/db.env"
   changed_when: false
-  # The env contains the postgres password.
+  # The env file may contain one or more passwords.
   no_log: true
 
 - name: Transfer dockerfile to remote.
@@ -48,7 +20,7 @@
     src: "{{ nd_docker_compose_project_src }}/docker-compose.yml.j2"
     dest: "{{ nd_docker_compose_project_dir }}/docker-compose.yml"
   changed_when: false
-  # The dockerfile contains the Redis host password.
+  # The dockerfile may contain one or more passwords.
   no_log: true
 
 - name: Copy Nextcloud dockerfile dependencies to remote.
@@ -73,66 +45,8 @@
   when: "nd_docker_compose_remove_project"
 
 - name: Test status of containers.
-  block:
-    - name: Assert Nextcloud app container is up and running.
-      assert:
-        that:
-          - "app.nextcloud_app_1.state.status == 'running'"
-        success_msg: "Nextcloud app container running."
-        fail_msg: >
-          Nextcloud app container status was
-          '{{ app.nextcloud_app_1.state.status }}'
-          (should have been 'running').
-
-    - name: Assert Nextcloud cron container is up and running.
-      assert:
-        that:
-          - "cron.nextcloud_cron_1.state.status == 'running'"
-        success_msg: "Nextcloud cron container running."
-        fail_msg: >
-          Nextcloud cron container status was
-          '{{ cron.nextcloud_cron_1.state.status }}'
-          (should have been 'running').
-      when: "nd_use_cron"
-
-    - name: Assert Nextcloud Nginx proxy container is up and running.
-      assert:
-        that:
-          - "proxy.nextcloud_proxy_1.state.status == 'running'"
-        success_msg: "Nextcloud Nginx proxy container running."
-        fail_msg: >
-          Nextcloud Nginx proxy container status was
-          '{{ proxy.nextcloud_proxy_1.state.status }}'
-          (should have been 'running').
-
-    - name: Assert Nextcloud Postgres container is up and running.
-      assert:
-        that:
-          - "db.nextcloud_db_1.state.status == 'running'"
-        success_msg: "Nextcloud db container running."
-        fail_msg: >
-          Nextcloud db container status was
-          '{{ db.nextcloud_db_1.state.status }}'
-          (should have been 'running').
-
-    - name: Assert Nextcloud Redis container is up and running.
-      assert:
-        that:
-          - "redis.nextcloud_redis_1.state.status == 'running'"
-        success_msg: "Nextcloud Redis container running."
-        fail_msg: >
-          Nextcloud redis container status was
-          '{{ redis.nextcloud_redis_1.state.status }}'
-          (should have been 'running').
-      when: "nd_use_redis"
-
-    - name: Assert Nextcloud Letsencrypt container is up and running.
-      assert:
-        that:
-          - "letsencrypt.nextcloud_letsencrypt_1.state.status == 'running'"
-        success_msg: "Nextcloud Letsencrypt container running."
-        fail_msg: >
-          Nextcloud Letsencrypt container status was
-          '{{ letsencrypt.nextcloud_letsencrypt_1.state.status }}'
-          (should have been 'running').
-      when: "nd_use_letsencrypt"
+  include_tasks:
+    file: "tasks/nd-docker-status.yml"
+  loop: "{{ nd_docker_compose | dict2items }}"
+  loop_control:
+    loop_var: container

--- a/tasks/nd-docker-status.yml
+++ b/tasks/nd-docker-status.yml
@@ -1,0 +1,21 @@
+---
+# tasks related to checking status of newly-created containers.
+
+- name: Find out the name for the current container.
+  set_fact:
+    nd_docker_container_name: "nextcloud_{{ container.key }}_1"
+
+- name: Retrieve info about the current container.
+  docker_container_info:
+    name: "{{ nd_docker_container_name }}"
+  register: current_container_info
+
+- name: Check status of '{{ nd_docker_container_name }}' container.
+  assert:
+    that:
+      - "current_container_info.container.State.Running is sameas true"
+    success_msg: "{{ nd_docker_container_name }} is up and running."
+    fail_msg: >
+      {{ nd_docker_container_name }} status was
+      '{{ nd_docker_container_name }}.state.status'
+      (should have been 'running').

--- a/tasks/nd-nextcloud-install.yml
+++ b/tasks/nd-nextcloud-install.yml
@@ -1,12 +1,12 @@
 ---
 # tasks related to Nextcloud installation for ansible-role-nextcloud-docker.
 
-- name: Don't proceed if expected Nextcloud files are not present.
-  wait_for:
-    delay: "5"
-    path: "/var/lib/docker/volumes/nextcloud_nextcloud/_data/lib/versioncheck.php"
-    search_regex: "<\\?php"
-    timeout: "60"
+# - name: Don't proceed if expected Nextcloud files are not present.
+#   wait_for:
+#     delay: "5"
+#     path: "/var/lib/docker/volumes/nextcloud_html/_data/lib/versioncheck.php"
+#     search_regex: "<\\?php"
+#     timeout: "60"
 
 - name: Check if Nextcloud is installed and install it if not.
   block:
@@ -23,4 +23,4 @@
       shell: "{{ nd_nextcloud_occ_prefix }} php occ {{ nd_nextcloud_occ_install_command }}"
       become: true
       when: "not nd_nextcloud_status.installed"
-      no_log: true
+      no_log: "{{ nd_secure_no_log }}"


### PR DESCRIPTION
This comes close to a total rewrite. Now, the role sticks quite close to the original docker-compose file with our template, generally replacing only volumes and env vars.

The default docker-compose generated includes `letsencrypt-companion`, `redis`, and `cron`, but the Molecule _tests_ demonstrate that it's only a modest task to remove `letsencrypt-companion` (which we can't easily test anyhow).